### PR TITLE
Stream 'oc new-app' output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+    }
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@mui/material';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
 import Logo from './components/logo';
 import CurrentContext from './ContextCard';
 import DeploymentOutput from './DeploymentOutput';
@@ -8,10 +7,8 @@ import Header from './Header';
 import { useLocalState } from './hooks/useStorageState';
 import ImageSelector from './imageSelector';
 import { ISelectedImage } from './models/IDockerImage';
-import { Deployer, DeploymentListener, DeploymentMode } from './utils/Deployer';
-import { ConsoleListener, getLocalImageInspectionJson, pushImage } from './utils/DockerUtils';
+import { Deployer, DeploymentMode } from './utils/Deployer';
 import { getMessage } from './utils/ErrorUtils';
-import { deployImage, exposeService, getAppName, getProjectRoute } from './utils/OcUtils';
 import { openInBrowser, toast } from './utils/UIUtils';
 import { waitOnUrl } from './utils/waitOnUrl';
 import Welcome from './Welcome';

--- a/client/src/imageSelector.tsx
+++ b/client/src/imageSelector.tsx
@@ -1,18 +1,16 @@
-import { Alert, Autocomplete, Button, Link, MenuItem, Paper, TextField, Tooltip } from "@mui/material";
+import { RefreshRounded } from "@mui/icons-material";
+import { Alert, Autocomplete, Button, Link, TextField, Tooltip } from "@mui/material";
 import { Box } from "@mui/system";
 import { useEffect, useState } from "react";
-import { getLocalImages } from "./utils/DockerUtils";
-import { useTheme } from '@mui/material';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
-import { IDockerImage, ISelectedImage } from "./models/IDockerImage";
-import { RefreshRounded } from "@mui/icons-material";
-import { openInBrowser, toast } from "./utils/UIUtils";
 import { useRecoilState } from "recoil";
-import { currentContextState } from "./state/currentContextState";
-import { UnknownKubeContext } from "./models/KubeContext";
-import { UNSET_VALUE } from "./utils/OcUtils";
 import DeployButton from "./components/deployButton";
+import { IDockerImage, ISelectedImage } from "./models/IDockerImage";
+import { UnknownKubeContext } from "./models/KubeContext";
+import { currentContextState } from "./state/currentContextState";
 import { DeploymentMode } from "./utils/Deployer";
+import { getLocalImages } from "./utils/DockerUtils";
+import { UNSET_VALUE } from "./utils/OcUtils";
+import { openInBrowser, toast } from "./utils/UIUtils";
 
 interface ImageSelectorProps {
   onDeployClick?: (image: ISelectedImage, mode: number) => void;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,9 +1,9 @@
+import { DockerMuiThemeProvider } from '@docker/docker-mui-theme';
+import CssBaseline from '@mui/material/CssBaseline';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import CssBaseline from '@mui/material/CssBaseline';
-import { DockerMuiThemeProvider } from '@docker/docker-mui-theme';
-import { App } from './App';
 import { RecoilRoot } from 'recoil';
+import { App } from './App';
 
 ReactDOM.render(
   <React.StrictMode>

--- a/client/src/utils/DockerUtils.ts
+++ b/client/src/utils/DockerUtils.ts
@@ -1,10 +1,6 @@
 import { createDockerDesktopClient } from "@docker/extension-api-client";
 import { IDockerImage, IDockerImageInspectOutput } from "../models/IDockerImage";
-
-export interface ConsoleListener {
-    onOutput(line: string): void;
-    onError(line: string): void;
-}
+import ExecListener from "./execListener";
 
 const ddClient = createDockerDesktopClient();
 /**
@@ -41,7 +37,7 @@ export async function getLocalImageInspectionJson(tag: string): Promise<IDockerI
 }
 
 // Push the image to docker hub
-export async function pushImage(imageName: string, listener?: ConsoleListener): Promise<void> {
+export async function pushImage(imageName: string, listener?: ExecListener): Promise<void> {
   return new Promise((resolve, reject) => {
     ddClient.docker.cli.exec('image', ['push', imageName], {
         stream: {

--- a/client/src/utils/execListener.ts
+++ b/client/src/utils/execListener.ts
@@ -1,0 +1,4 @@
+export default interface ExecListener {
+    onOutput(line: string): void;
+    onError(line: string): void;
+}


### PR DESCRIPTION
... so  the deployment process appears a bit more fluid, instead of displaying the output all at once at the end.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
