### PR TITLE
Deploy to OpenShift container registry

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "validator": "^13.7.0"
   },
   "devDependencies": {
-    "@docker/extension-api-client-types": "^0.2.2",
+    "@docker/extension-api-client-types": "^0.2.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@types/jest": "^27.5.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Header from './Header';
 import { useLocalState } from './hooks/useStorageState';
 import ImageSelector from './imageSelector';
 import { ISelectedImage } from './models/IDockerImage';
+import { KubeContext } from './models/KubeContext';
 import { Deployer, DeploymentMode } from './utils/Deployer';
 import { getMessage } from './utils/ErrorUtils';
 import { openInBrowser, toast } from './utils/UIUtils';
@@ -18,7 +19,7 @@ const WAITING_ON_URL_TIMEOUT = 30000;
 export function App() {
   const [deployResponse, setDeployResponse] = useState("");
 
-  async function deploy(selectedImage: ISelectedImage, mode: DeploymentMode) {
+  async function deploy(selectedImage: ISelectedImage,  mode: DeploymentMode, context: KubeContext, registry?: string) {
     const imageName = selectedImage.name;
     let output = "";
     const deployer = new Deployer(mode, { 
@@ -43,7 +44,7 @@ export function App() {
       }
     });
     try {
-      deployer.deploy(imageName);
+      await deployer.deploy(imageName, context, registry);
     } catch (error) {
       toast.error(getMessage(error));
       setDeployResponse(output += `${getMessage(error)}\n`);

--- a/client/src/ContextCard.tsx
+++ b/client/src/ContextCard.tsx
@@ -6,6 +6,7 @@ import { Box, Button, Card, CardContent, CardHeader, IconButton, Tooltip } from 
 import { Suspense, useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import ConsoleButton from './components/consoleButton';
+import RegistryUrl from './components/registryUrl';
 import { ChangeContext } from './dialogs/changeContext';
 import { ChangeProject } from './dialogs/changeProject';
 import { LoginDialog } from './dialogs/login';
@@ -15,7 +16,7 @@ import { loadKubeContext } from './utils/OcUtils';
 import { openInBrowser } from './utils/UIUtils';
 
 export default function CurrentContext() {
-  const [loading, setLoading] = useState(true);
+  const [loading, ] = useState(true);
   const [currentContext, setCurrentContext] = useRecoilState(currentContextState);
   const [expanded, setExpanded] = useState(false);
   
@@ -123,6 +124,11 @@ export default function CurrentContext() {
         />
         <CardContent hidden={!expanded} sx={{ paddingTop: "0px" }}>
           <Box><b>Server:</b> <a onClick={openClusterPage} href="" style={styles.link}>{currentContext.clusterUrl}</a></Box>
+          <Box><b>Container Registry:</b> <span>
+            <Suspense fallback="...">
+              <RegistryUrl/>
+            </Suspense></span>
+          </Box>
           <Box><b>User:</b> {currentContext.user}</Box>
           <Box><b>Project:</b> {currentContext.project}
             {(currentContext !== UnknownKubeContext) && (

--- a/client/src/components/deployButton.tsx
+++ b/client/src/components/deployButton.tsx
@@ -1,30 +1,41 @@
-import * as React from 'react';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Grow from '@mui/material/Grow';
-import Paper from '@mui/material/Paper';
-import Popper from '@mui/material/Popper';
 import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import { Fragment, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { KubeContext } from '../models/KubeContext';
+import { currentContextState, currentOpenShiftRegistryState } from '../state/currentContextState';
 
-const options = ['Deploy', 'Push to Hub and Deploy'];//, 'Push to OpenShift and Deploy'];
 
 interface DeployButtonProps {
-  onDeployClick: (mode: number) => void;
+  onDeployClick: (mode: number, context: KubeContext, registry?: string) => void;
   disabled?: boolean;
 }
 
 export default function DeployButton(props: DeployButtonProps) {
   const onDeployClick = props.onDeployClick;
   const disabled = props.disabled;
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
-  const [selectedIndex, setSelectedIndex] = React.useState(0);
-
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const registryUrl = useRecoilValue(currentOpenShiftRegistryState);
+  const context = useRecoilValue(currentContextState);
+  const disabledIndex = (registryUrl)?-1:2;
+  const options = ['Deploy', 'Push to Hub and Deploy']
+  if (registryUrl) {
+    options.push('Push to OpenShift and Deploy');
+  }
+  if (selectedIndex > options.length -1) {
+    setSelectedIndex(0);
+  }
   const handleClick = () => {
-    onDeployClick(selectedIndex);
+    onDeployClick(selectedIndex, context, registryUrl);
   };
 
   const handleMenuItemClick = (
@@ -51,7 +62,7 @@ export default function DeployButton(props: DeployButtonProps) {
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       <ButtonGroup 
         size="large" 
         style={{ marginLeft: '20px' }}
@@ -93,7 +104,7 @@ export default function DeployButton(props: DeployButtonProps) {
                   {options.map((option, index) => (
                     <MenuItem
                       key={option}
-                      disabled={index === 2}
+                      disabled={index === disabledIndex}
                       selected={index === selectedIndex}
                       onClick={(event) => handleMenuItemClick(event, index)}
                     >
@@ -106,6 +117,6 @@ export default function DeployButton(props: DeployButtonProps) {
           </Grow>
         )}
       </Popper>
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/client/src/components/registryUrl.tsx
+++ b/client/src/components/registryUrl.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from "recoil";
+import { currentOpenShiftRegistryState } from "../state/currentContextState";
+
+export default function RegistryUrl() {
+    const registryUrl = useRecoilValue(currentOpenShiftRegistryState);
+
+    return (registryUrl)?<>{registryUrl}</>:<>Unavailable</>;
+}

--- a/client/src/imageSelector.tsx
+++ b/client/src/imageSelector.tsx
@@ -1,11 +1,11 @@
 import { RefreshRounded } from "@mui/icons-material";
 import { Alert, Autocomplete, Button, Link, TextField, Tooltip } from "@mui/material";
 import { Box } from "@mui/system";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRecoilState } from "recoil";
 import DeployButton from "./components/deployButton";
 import { IDockerImage, ISelectedImage } from "./models/IDockerImage";
-import { UnknownKubeContext } from "./models/KubeContext";
+import { KubeContext, UnknownKubeContext } from "./models/KubeContext";
 import { currentContextState } from "./state/currentContextState";
 import { DeploymentMode } from "./utils/Deployer";
 import { getLocalImages } from "./utils/DockerUtils";
@@ -13,7 +13,7 @@ import { UNSET_VALUE } from "./utils/OcUtils";
 import { openInBrowser, toast } from "./utils/UIUtils";
 
 interface ImageSelectorProps {
-  onDeployClick?: (image: ISelectedImage, mode: number) => void;
+  onDeployClick?: (image: ISelectedImage, mode: number, context: KubeContext, registry?: string) => void;
 }
 
 interface ImageOption {
@@ -62,9 +62,9 @@ export default function ImageSelector(props?: ImageSelectorProps) {
     setLoading(true);
   }
 
-  const deploy = (mode: DeploymentMode): void => {
+  const deploy = (mode: DeploymentMode, context: KubeContext, registry?: string): void => {
     if (selectedImage && onDeployClick) {
-      onDeployClick(selectedImage, mode);
+      onDeployClick(selectedImage, mode, currentContext, registry);
     }
   }
 
@@ -126,11 +126,13 @@ export default function ImageSelector(props?: ImageSelectorProps) {
           </span>
         </Tooltip>
         {/* Move tooltip to the top-end, so it doesn't overlap the drop-down menu */}
+        <Suspense fallback={<Button size="large" variant="contained" style={{ marginLeft: '20px' }}>Loading options ...</Button>}>
         <Tooltip title="Deploy the selected image to OpenShift" placement='top-end'> 
           <span>
             <DeployButton onDeployClick={deploy} disabled={!selectedImage}/>
           </span>
         </Tooltip>
+        </Suspense>
       </Box>
       <Box marginBottom="15px">
         <Alert variant="filled" severity="info">

--- a/client/src/utils/DockerUtils.ts
+++ b/client/src/utils/DockerUtils.ts
@@ -25,7 +25,6 @@ export async function getLocalImages(): Promise<Map<string, IDockerImage>> {
 }
 
 export async function getLocalImageInspectionJson(tag: string): Promise<IDockerImageInspectOutput[] | undefined> {
-
   try {
     const result = await ddClient.docker.cli.exec('image', ['inspect', tag]);
     const resultJson = JSON.parse(result.stdout)
@@ -39,6 +38,7 @@ export async function getLocalImageInspectionJson(tag: string): Promise<IDockerI
 // Push the image to docker hub
 export async function pushImage(imageName: string, listener?: ExecListener): Promise<void> {
   return new Promise((resolve, reject) => {
+    let err ='';
     ddClient.docker.cli.exec('image', ['push', imageName], {
         stream: {
           onOutput(data) {
@@ -49,6 +49,7 @@ export async function pushImage(imageName: string, listener?: ExecListener): Pro
               } 
               if (data.stderr) {
                 console.error(data.stderr);
+                err += data.stderr;
                 listener.onError(data.stderr);
               }
             }
@@ -64,12 +65,88 @@ export async function pushImage(imageName: string, listener?: ExecListener): Pro
             if (exitCode === 0) {
               resolve();
             } else {
-              reject(exitCode);
+              reject("docker push failed: "+err);
             }
           },
           splitOutputLines: true
       }
     });
   });
+}
   
+export async function tagImage(imageName: string, newTag: string, listener?: ExecListener): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ddClient.docker.cli.exec('tag', [imageName, newTag], {
+          stream: {
+            onOutput(data) {
+              if (listener) {
+                if (data.stdout) {
+                  console.log(data.stdout);
+                  listener.onOutput(data.stdout);
+                } 
+                if (data.stderr) {
+                  console.error(data.stderr);
+                  listener.onError(data.stderr);
+                }
+              }
+            },
+            onError(error) {
+              console.error(error);
+              if (listener) {
+                listener.onError(error);
+              }
+            },
+            onClose(exitCode) {
+              console.log("docker tag ended with exit code " + exitCode);
+              if (exitCode === 0) {
+                resolve();
+              } else {
+                reject(exitCode);
+              }
+            },
+            splitOutputLines: true
+        }
+    });
+  });
+}
+
+export async function removeTag(tag: string, listener?: ExecListener): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ddClient.docker.cli.exec('rmi', [tag], {
+          stream: {
+            onOutput(data) {
+              if (listener) {
+                if (data.stdout) {
+                  console.log(data.stdout);
+                  listener.onOutput(data.stdout);
+                } 
+                if (data.stderr) {
+                  console.error(data.stderr);
+                  listener.onError(data.stderr);
+                }
+              }
+            },
+            onError(error) {
+              console.error(error);
+              if (listener) {
+                listener.onError(error);
+              }
+            },
+            onClose(exitCode) {
+              console.log("docker rmi ended with exit code " + exitCode);
+              if (exitCode === 0) {
+                resolve();
+              } else {
+                reject(exitCode);
+              }
+            },
+            splitOutputLines: true
+        }
+    });
+  });
+}
+
+export function buildTag(registry: string, namespace: string, originalTag: string): string {
+  const lastPart = originalTag.split('/').pop();
+  return registry + '/' + namespace + '/' + lastPart;
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1136,6 +1136,11 @@
   resolved "https://registry.npmjs.org/@docker/extension-api-client-types/-/extension-api-client-types-0.2.2.tgz"
   integrity sha512-+RiekqZ7sacKZpIm3SguRLX+YurCwNhgBGrUoLdY8PIYKzJ6NZd2+ExX3wyT+lxCYOFEW9Yh/gdcXWvjVOktzw==
 
+"@docker/extension-api-client-types@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@docker/extension-api-client-types/-/extension-api-client-types-0.2.3.tgz#4711e81a18266bf7e8b15734cd7daeb221db1312"
+  integrity sha512-KecgDPmH0Ma7UpwQGAbVQnMCFC9dLvlngWT0jP0uXObxISaPVhHnOzbb+5d+VikazV82Dj7E24ySKJOpKUYHDA==
+
 "@docker/extension-api-client@^0.2.2":
   version "0.2.2"
   resolved "https://registry.npmjs.org/@docker/extension-api-client/-/extension-api-client-0.2.2.tgz"


### PR DESCRIPTION
This change does the following:
 
- [x] fetches the registry url from the current context with `oc registry info`
- [x] provides a `Push to OpenShift and Deploy` option if the registry is available 
- [x] logs into the target registry with `oc registry login`
- [x] creates a new imagestream with the image name  with `oc create imagestream`
- [x] tags image matching imagestream
- [x] push new tag to target registry

Fixes #49  

https://user-images.githubusercontent.com/148698/182432094-6db694d2-2f58-4a3a-a4c5-4f8c196ca937.mp4

