### PR TITLE
login: Add Skip TLS Verify checkbox

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import Logo from './components/logo';
 import CurrentContext from './ContextCard';
 import DeploymentOutput from './DeploymentOutput';
@@ -8,6 +9,7 @@ import { useLocalState } from './hooks/useStorageState';
 import ImageSelector from './imageSelector';
 import { ISelectedImage } from './models/IDockerImage';
 import { KubeContext } from './models/KubeContext';
+import { currentOcOptions } from './state/currentOcOptionsState';
 import { Deployer, DeploymentMode } from './utils/Deployer';
 import { getMessage } from './utils/ErrorUtils';
 import { openInBrowser, toast } from './utils/UIUtils';
@@ -17,12 +19,13 @@ import Welcome from './Welcome';
 const WAITING_ON_URL_TIMEOUT = 30000;
 
 export function App() {
+  const ocOptions = useRecoilValue(currentOcOptions);
   const [deployResponse, setDeployResponse] = useState("");
 
   async function deploy(selectedImage: ISelectedImage,  mode: DeploymentMode, context: KubeContext, registry?: string) {
     const imageName = selectedImage.name;
     let output = "";
-    const deployer = new Deployer(mode, { 
+    const deployer = new Deployer(ocOptions, mode, { 
       onMessage(message) {
         setDeployResponse(output += `${message}\n`);
       },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,7 +9,7 @@ import { useLocalState } from './hooks/useStorageState';
 import ImageSelector from './imageSelector';
 import { ISelectedImage } from './models/IDockerImage';
 import { KubeContext } from './models/KubeContext';
-import { currentOcOptions } from './state/currentOcOptionsState';
+import { currentOcOptionsState } from './state/currentOcOptionsState';
 import { Deployer, DeploymentMode } from './utils/Deployer';
 import { getMessage } from './utils/ErrorUtils';
 import { openInBrowser, toast } from './utils/UIUtils';
@@ -19,13 +19,13 @@ import Welcome from './Welcome';
 const WAITING_ON_URL_TIMEOUT = 30000;
 
 export function App() {
-  const ocOptions = useRecoilValue(currentOcOptions);
+  const currentOcOptions = useRecoilValue(currentOcOptionsState);
   const [deployResponse, setDeployResponse] = useState("");
 
   async function deploy(selectedImage: ISelectedImage,  mode: DeploymentMode, context: KubeContext, registry?: string) {
     const imageName = selectedImage.name;
     let output = "";
-    const deployer = new Deployer(ocOptions, mode, { 
+    const deployer = new Deployer(currentOcOptions, mode, { 
       onMessage(message) {
         setDeployResponse(output += `${message}\n`);
       },

--- a/client/src/ContextCard.tsx
+++ b/client/src/ContextCard.tsx
@@ -13,14 +13,14 @@ import { LoginDialog } from './dialogs/login';
 import { UnknownKubeContext } from './models/KubeContext';
 import { OcOptions } from './models/OcOptions';
 import { currentContextState } from './state/currentContextState';
-import { currentOcOptions } from './state/currentOcOptionsState';
+import { currentOcOptionsState } from './state/currentOcOptionsState';
 import { loadKubeContext } from './utils/OcUtils';
 import { openInBrowser } from './utils/UIUtils';
 
 export default function CurrentContext() {
   const [loading, ] = useState(true);
   const [currentContext, setCurrentContext] = useRecoilState(currentContextState);
-  const [ocOptions, setOcOptions] = useRecoilState(currentOcOptions);
+  const [currentOcOptions, setCurrentOcOptions] = useRecoilState(currentOcOptionsState);
   const [expanded, setExpanded] = useState(false);
   
   const handleLogin = () => {
@@ -61,7 +61,7 @@ export default function CurrentContext() {
   }
 
   const onLogin = (ocOptions: OcOptions) => {
-    setOcOptions(ocOptions);
+    setCurrentOcOptions(ocOptions);
     loadContext();
   }
 
@@ -141,7 +141,7 @@ export default function CurrentContext() {
               </Tooltip>
             )}
           </Box>
-          <Box><b>Skip TLS Verify:</b> {ocOptions.skipTlsVerify}</Box>
+          <Box><b>Skip TLS Verify:</b> {currentOcOptions.skipTlsVerify}</Box>
         </CardContent>
       </Card >
       <LoginDialog install={installDialog} onLogin={onLogin} />

--- a/client/src/ContextCard.tsx
+++ b/client/src/ContextCard.tsx
@@ -56,7 +56,7 @@ export default function CurrentContext() {
   }
 
   async function loadContext(): Promise<void> {
-    const context = await loadKubeContext(ocOptions);
+    const context = await loadKubeContext();
     setCurrentContext(context);
   }
 

--- a/client/src/ContextCard.tsx
+++ b/client/src/ContextCard.tsx
@@ -165,7 +165,7 @@ export default function CurrentContext() {
               </Tooltip>
             )}
           </Box>
-          <Box><b>Skip TLS Verify:</b> {currentOcOptions.skipTlsVerify}</Box>
+          <Box><b>Skip TLS Verify:</b> {currentOcOptions.skipTlsVerify.toString()}</Box>
         </CardContent>
       </Card >
       <LoginDialog install={installDialog} onLogin={onLogin} />

--- a/client/src/ContextCard.tsx
+++ b/client/src/ContextCard.tsx
@@ -21,7 +21,7 @@ import { openInBrowser } from './utils/UIUtils';
 export default function CurrentContext() {
   const [loading, ] = useState(true);
   const [currentContext, setCurrentContext] = useRecoilState(currentContextState);
-  const [clusterUrlsToOcOptions, setClusterUrlToOcOptions] = useLocalState('ocOptions', {} as any);
+  const [contextNamesToOcOptions, setContextNamesToOcOptions] = useLocalState('ocOptions', {} as any);
   const [currentOcOptions, setCurrentOcOptions] = useRecoilState(currentOcOptionsState);
   const [expanded, setExpanded] = useState(false);
   
@@ -69,8 +69,8 @@ export default function CurrentContext() {
   }
 
   function loadOcOptions() {
-    if (currentContext.clusterUrl) {
-      const ocOptions: OcOptions = clusterUrlsToOcOptions[currentContext.clusterUrl];
+    if (currentContext.name) {
+      const ocOptions: OcOptions = contextNamesToOcOptions[currentContext.name];
       if (ocOptions) {
         setCurrentOcOptions(ocOptions);
       }
@@ -79,10 +79,10 @@ export default function CurrentContext() {
 
   const onLogin = (ocOptions: OcOptions) => {
     loadContext().then(() => {
-      if (currentContext.clusterUrl) {
-        setClusterUrlToOcOptions({
-          ...clusterUrlsToOcOptions,
-          [currentContext.clusterUrl]: ocOptions,
+      if (currentContext.name) {
+        setContextNamesToOcOptions({
+          ...contextNamesToOcOptions,
+          [currentContext.name]: ocOptions,
         });
       }
       loadOcOptions();

--- a/client/src/ContextCard.tsx
+++ b/client/src/ContextCard.tsx
@@ -11,13 +11,16 @@ import { ChangeContext } from './dialogs/changeContext';
 import { ChangeProject } from './dialogs/changeProject';
 import { LoginDialog } from './dialogs/login';
 import { UnknownKubeContext } from './models/KubeContext';
+import { OcOptions } from './models/OcOptions';
 import { currentContextState } from './state/currentContextState';
+import { currentOcOptions } from './state/currentOcOptionsState';
 import { loadKubeContext } from './utils/OcUtils';
 import { openInBrowser } from './utils/UIUtils';
 
 export default function CurrentContext() {
   const [loading, ] = useState(true);
   const [currentContext, setCurrentContext] = useRecoilState(currentContextState);
+  const [ocOptions, setOcOptions] = useRecoilState(currentOcOptions);
   const [expanded, setExpanded] = useState(false);
   
   const handleLogin = () => {
@@ -53,11 +56,12 @@ export default function CurrentContext() {
   }
 
   async function loadContext(): Promise<void> {
-    const context = await loadKubeContext();
+    const context = await loadKubeContext(ocOptions);
     setCurrentContext(context);
   }
 
-  const onLogin = () => {
+  const onLogin = (ocOptions: OcOptions) => {
+    setOcOptions(ocOptions);
     loadContext();
   }
 
@@ -137,6 +141,7 @@ export default function CurrentContext() {
               </Tooltip>
             )}
           </Box>
+          <Box><b>Skip TLS Verify:</b> {ocOptions.skipTlsVerify}</Box>
         </CardContent>
       </Card >
       <LoginDialog install={installDialog} onLogin={onLogin} />

--- a/client/src/dialogs/changeContext.tsx
+++ b/client/src/dialogs/changeContext.tsx
@@ -7,7 +7,9 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import * as React from 'react';
+import { useRecoilValue } from 'recoil';
 import { UnknownKubeContext } from '../models/KubeContext';
+import { currentOcOptions } from '../state/currentOcOptionsState';
 import { loadContextUiData, readKubeConfig, setCurrentContext } from '../utils/OcUtils';
 
 interface LoginDialogProps {
@@ -17,6 +19,7 @@ interface LoginDialogProps {
 }
 
 export function ChangeContext(props: LoginDialogProps) {
+  const ocOptions = useRecoilValue(currentOcOptions);
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [kubeConfig, setKubeConfig] = React.useState();
@@ -36,7 +39,7 @@ export function ChangeContext(props: LoginDialogProps) {
 
   const handleChange = () => {
     setOpen(false);
-    setCurrentContext(selectedContext).catch((error) => {
+    setCurrentContext(ocOptions, selectedContext).catch((error) => {
       console.error(error);
       ddClient.desktopUI.toast.error('Setting current context failed.');
     }).then(() => {
@@ -47,7 +50,7 @@ export function ChangeContext(props: LoginDialogProps) {
   const handleOpen = () => {
     setLoading(true);
     setOpen(true)
-    readKubeConfig().then((kubeConfig) => {
+    readKubeConfig(ocOptions).then((kubeConfig) => {
       setKubeConfig(kubeConfig);
       setContexts(kubeConfig.contexts ? kubeConfig.contexts : [])
       setSelectedContext(kubeConfig['current-context']);

--- a/client/src/dialogs/changeContext.tsx
+++ b/client/src/dialogs/changeContext.tsx
@@ -50,7 +50,7 @@ export function ChangeContext(props: LoginDialogProps) {
   const handleOpen = () => {
     setLoading(true);
     setOpen(true)
-    readKubeConfig(ocOptions).then((kubeConfig) => {
+    readKubeConfig().then((kubeConfig) => {
       setKubeConfig(kubeConfig);
       setContexts(kubeConfig.contexts ? kubeConfig.contexts : [])
       setSelectedContext(kubeConfig['current-context']);

--- a/client/src/dialogs/changeContext.tsx
+++ b/client/src/dialogs/changeContext.tsx
@@ -9,7 +9,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import * as React from 'react';
 import { useRecoilValue } from 'recoil';
 import { UnknownKubeContext } from '../models/KubeContext';
-import { currentOcOptions } from '../state/currentOcOptionsState';
+import { currentOcOptionsState } from '../state/currentOcOptionsState';
 import { loadContextUiData, readKubeConfig, setCurrentContext } from '../utils/OcUtils';
 
 interface LoginDialogProps {
@@ -19,7 +19,7 @@ interface LoginDialogProps {
 }
 
 export function ChangeContext(props: LoginDialogProps) {
-  const ocOptions = useRecoilValue(currentOcOptions);
+  const currentOcOptions = useRecoilValue(currentOcOptionsState);
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [kubeConfig, setKubeConfig] = React.useState();
@@ -39,7 +39,7 @@ export function ChangeContext(props: LoginDialogProps) {
 
   const handleChange = () => {
     setOpen(false);
-    setCurrentContext(ocOptions, selectedContext).catch((error) => {
+    setCurrentContext(currentOcOptions, selectedContext).catch((error) => {
       console.error(error);
       ddClient.desktopUI.toast.error('Setting current context failed.');
     }).then(() => {

--- a/client/src/dialogs/changeProject.tsx
+++ b/client/src/dialogs/changeProject.tsx
@@ -7,6 +7,8 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import * as React from 'react';
+import { useRecoilValue } from 'recoil';
+import { currentOcOptions } from '../state/currentOcOptionsState';
 import { getMessage } from '../utils/ErrorUtils';
 import { loadKubeContext, loadProjectNames, setCurrentContextProject } from '../utils/OcUtils';
 import { NewProjectDialog } from './newProject';
@@ -17,6 +19,7 @@ export interface ChangeProjectDialogProps {
 }
 
 export function ChangeProject(props: ChangeProjectDialogProps) {
+  const ocOptions = useRecoilValue(currentOcOptions);
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [changing, setChanging] = React.useState(false);
@@ -32,7 +35,7 @@ export function ChangeProject(props: ChangeProjectDialogProps) {
 
   const handleChange = () => {
     setChanging(true);
-    setCurrentContextProject(selectedProject).catch((error) => {
+    setCurrentContextProject(ocOptions, selectedProject).catch((error) => {
       console.error(error);
       ddClient.desktopUI.toast.error('Setting current project for current context failed.');
     }).then(() => {
@@ -54,10 +57,10 @@ export function ChangeProject(props: ChangeProjectDialogProps) {
   const handleOpen = () => {
     setLoading(true);
     setOpen(true)
-    loadKubeContext().then((context) => {
+    loadKubeContext(ocOptions).then((context) => {
       setCurrentProject(context.project ? context.project : '');
       setSelectedProject(context.project ? context.project : '');
-      loadProjectNames().then((projects) => {
+      loadProjectNames(ocOptions).then((projects) => {
         setProjects(projects); 1
         setLoading(false);
       }).catch((error) => {

--- a/client/src/dialogs/changeProject.tsx
+++ b/client/src/dialogs/changeProject.tsx
@@ -8,7 +8,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import * as React from 'react';
 import { useRecoilValue } from 'recoil';
-import { currentOcOptions } from '../state/currentOcOptionsState';
+import { currentOcOptionsState } from '../state/currentOcOptionsState';
 import { getMessage } from '../utils/ErrorUtils';
 import { loadKubeContext, loadProjectNames, setCurrentContextProject } from '../utils/OcUtils';
 import { NewProjectDialog } from './newProject';
@@ -19,7 +19,7 @@ export interface ChangeProjectDialogProps {
 }
 
 export function ChangeProject(props: ChangeProjectDialogProps) {
-  const ocOptions = useRecoilValue(currentOcOptions);
+  const currentOcOptions = useRecoilValue(currentOcOptionsState);
   const [open, setOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [changing, setChanging] = React.useState(false);
@@ -35,7 +35,7 @@ export function ChangeProject(props: ChangeProjectDialogProps) {
 
   const handleChange = () => {
     setChanging(true);
-    setCurrentContextProject(ocOptions, selectedProject).catch((error) => {
+    setCurrentContextProject(currentOcOptions, selectedProject).catch((error) => {
       console.error(error);
       ddClient.desktopUI.toast.error('Setting current project for current context failed.');
     }).then(() => {
@@ -60,7 +60,7 @@ export function ChangeProject(props: ChangeProjectDialogProps) {
     loadKubeContext().then((context) => {
       setCurrentProject(context.project ? context.project : '');
       setSelectedProject(context.project ? context.project : '');
-      loadProjectNames(ocOptions).then((projects) => {
+      loadProjectNames(currentOcOptions).then((projects) => {
         setProjects(projects); 1
         setLoading(false);
       }).catch((error) => {

--- a/client/src/dialogs/changeProject.tsx
+++ b/client/src/dialogs/changeProject.tsx
@@ -57,7 +57,7 @@ export function ChangeProject(props: ChangeProjectDialogProps) {
   const handleOpen = () => {
     setLoading(true);
     setOpen(true)
-    loadKubeContext(ocOptions).then((context) => {
+    loadKubeContext().then((context) => {
       setCurrentProject(context.project ? context.project : '');
       setSelectedProject(context.project ? context.project : '');
       loadProjectNames(ocOptions).then((projects) => {

--- a/client/src/dialogs/login.tsx
+++ b/client/src/dialogs/login.tsx
@@ -2,11 +2,13 @@ import { createDockerDesktopClient } from '@docker/extension-api-client';
 import { Box, Tab, Tabs } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
 import * as React from 'react';
 import validator from 'validator';
@@ -33,6 +35,7 @@ const DEFAULT_STATUS = { value: '', helperText: '', error: false };
 export function LoginDialog(props: LoginDialogProps) {
   const [open, setOpen] = React.useState(false);
   const [cluster, setCluster] = React.useState<FieldState>(DEFAULT_STATUS);
+  const [skipTlsVerify, setSkipTlsVerify] = React.useState(false);
   const [username, setUsername] = React.useState<FieldState>(DEFAULT_STATUS);
   const [password, setPassword] = React.useState<FieldState>(DEFAULT_STATUS);
   const [token, setToken] = React.useState<FieldState>(DEFAULT_STATUS);;
@@ -75,9 +78,9 @@ export function LoginDialog(props: LoginDialogProps) {
     const host = cluster.value.split('://')[1];
     let loginPromise: Promise<void>;
     if (tab === TOKEN_TAB) {
-      loginPromise = loginWithToken(host, token.value);
+      loginPromise = loginWithToken(host, token.value, skipTlsVerify);
     } else {
-      loginPromise = login(host, username.value, password.value);
+      loginPromise = login(host, username.value, password.value, skipTlsVerify);
     }
     loginPromise.then(() => {
       ddClient.desktopUI.toast.success(`Sucessfully logged into cluster ${cluster.value}`);
@@ -220,6 +223,7 @@ export function LoginDialog(props: LoginDialogProps) {
               />
             )}
           />
+          <FormControlLabel control={<Checkbox checked={skipTlsVerify} onChange={(event, value) => setSkipTlsVerify(value)} />} label="Skip TLS Verify" />
           <Tabs value={tab} aria-label="Authentication options" onChange={handleTabChange}>
             <Tab label="Credentials" {...a11yProps(CREDENTIALS_TAB)} />
             <Tab label="Bearer Token" {...a11yProps(TOKEN_TAB)} />

--- a/client/src/dialogs/login.tsx
+++ b/client/src/dialogs/login.tsx
@@ -99,9 +99,7 @@ export function LoginDialog(props: LoginDialogProps) {
 
   const handleOpen = () => {
     setOpen(true);
-    loadServerUrls({
-      skipTlsVerify,
-    }).then((urls) => {
+    loadServerUrls().then((urls) => {
       setServers(urls);
     })
   }

--- a/client/src/dialogs/newProject.tsx
+++ b/client/src/dialogs/newProject.tsx
@@ -8,7 +8,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
 import * as React from 'react';
 import { useRecoilValue } from 'recoil';
-import { currentOcOptions } from '../state/currentOcOptionsState';
+import { currentOcOptionsState } from '../state/currentOcOptionsState';
 import { getMessage } from '../utils/ErrorUtils';
 import { createProject } from '../utils/OcUtils';
 import { validateLength, validateResourcePattern } from '../utils/ValidationUtils';
@@ -28,7 +28,7 @@ interface FieldState {
 const DEFAULT_STATUS = { value: '', helperText: '', error: false };
 
 export function NewProjectDialog(props: LoginDialogProps) {
-  const ocOptions = useRecoilValue(currentOcOptions);
+  const currentOcOptions = useRecoilValue(currentOcOptionsState);
   const [open, setOpen] = React.useState(false);
   const [name, setName] = React.useState<FieldState>(DEFAULT_STATUS);
 
@@ -60,7 +60,7 @@ export function NewProjectDialog(props: LoginDialogProps) {
   const ddClient = createDockerDesktopClient();
 
   const handleCreateProject = () => {
-    createProject(ocOptions, name.value).then(() => {
+    createProject(currentOcOptions, name.value).then(() => {
       ddClient.desktopUI.toast.success(`New Project '${name.value}' created.`);
       props.onCreate();
     }).catch((error) => {

--- a/client/src/dialogs/newProject.tsx
+++ b/client/src/dialogs/newProject.tsx
@@ -1,15 +1,17 @@
-import * as React from 'react';
+import { createDockerDesktopClient } from '@docker/extension-api-client';
 import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import { createProject } from '../utils/OcUtils';
-import { createDockerDesktopClient } from '@docker/extension-api-client';
-import { validateLength, validateResourcePattern } from '../utils/ValidationUtils';
+import TextField from '@mui/material/TextField';
+import * as React from 'react';
+import { useRecoilValue } from 'recoil';
+import { currentOcOptions } from '../state/currentOcOptionsState';
 import { getMessage } from '../utils/ErrorUtils';
+import { createProject } from '../utils/OcUtils';
+import { validateLength, validateResourcePattern } from '../utils/ValidationUtils';
 
 interface LoginDialogProps {
   existingProjects?: string[];
@@ -26,6 +28,7 @@ interface FieldState {
 const DEFAULT_STATUS = { value: '', helperText: '', error: false };
 
 export function NewProjectDialog(props: LoginDialogProps) {
+  const ocOptions = useRecoilValue(currentOcOptions);
   const [open, setOpen] = React.useState(false);
   const [name, setName] = React.useState<FieldState>(DEFAULT_STATUS);
 
@@ -57,7 +60,7 @@ export function NewProjectDialog(props: LoginDialogProps) {
   const ddClient = createDockerDesktopClient();
 
   const handleCreateProject = () => {
-    createProject(name.value).then(() => {
+    createProject(ocOptions, name.value).then(() => {
       ddClient.desktopUI.toast.success(`New Project '${name.value}' created.`);
       props.onCreate();
     }).catch((error) => {

--- a/client/src/models/OcOptions.ts
+++ b/client/src/models/OcOptions.ts
@@ -1,0 +1,3 @@
+export interface OcOptions {
+  skipTlsVerify: boolean;
+}

--- a/client/src/state/currentContextState.ts
+++ b/client/src/state/currentContextState.ts
@@ -2,6 +2,7 @@ import { atom, selector } from "recoil";
 import { UnknownKubeContext } from "../models/KubeContext";
 import { getMessage } from "../utils/ErrorUtils";
 import { getOpenShiftConsoleURL, getOpenShiftRegistryURL } from "../utils/OcUtils";
+import { currentOcOptions } from "./currentOcOptionsState";
 
 export const currentContextState = atom({
   key: 'contextState',
@@ -17,6 +18,7 @@ const NO_REGISTRY = 'no-registry';
 export const currentDashboardState = selector({
   key: 'dashboardState',
   get:  async ({get}) => {
+    const ocOptions = get(currentOcOptions);
     const context = get(currentContextState);
     if (context === UnknownKubeContext || !context.clusterUrl) {
       return undefined;
@@ -28,7 +30,7 @@ export const currentDashboardState = selector({
       return (NO_CONSOLE === url) ? undefined : url;
     }
     try {
-      consoleUrl = await getOpenShiftConsoleURL(context);
+      consoleUrl = await getOpenShiftConsoleURL(ocOptions, context);
       console.info(`Console url for ${context.clusterUrl}: ${consoleUrl}`);
     } catch (e) {
       console.error(`Error finding console url for ${context.clusterUrl}: ${getMessage(e)}`);
@@ -41,6 +43,7 @@ export const currentDashboardState = selector({
 export const currentOpenShiftRegistryState = selector({
   key: 'openShiftRegistryState',
   get:  async ({get}) => {
+    const ocOptions = get(currentOcOptions);
     const context = get(currentContextState);
     if (context === UnknownKubeContext || !context.clusterUrl) {
       return undefined;
@@ -52,7 +55,7 @@ export const currentOpenShiftRegistryState = selector({
       return (NO_REGISTRY === url) ? undefined : url;
     }
     try {
-      registryUrl = await getOpenShiftRegistryURL(context);
+      registryUrl = await getOpenShiftRegistryURL(ocOptions, context);
       console.info(`Container registry url for ${context.clusterUrl}: ${registryUrl}`);
     } catch (e) {
       console.error(`Error finding container registry url for ${context.clusterUrl}: ${getMessage(e)}`);

--- a/client/src/state/currentContextState.ts
+++ b/client/src/state/currentContextState.ts
@@ -2,7 +2,7 @@ import { atom, selector } from "recoil";
 import { UnknownKubeContext } from "../models/KubeContext";
 import { getMessage } from "../utils/ErrorUtils";
 import { getOpenShiftConsoleURL, getOpenShiftRegistryURL } from "../utils/OcUtils";
-import { currentOcOptions } from "./currentOcOptionsState";
+import { currentOcOptionsState } from "./currentOcOptionsState";
 
 export const currentContextState = atom({
   key: 'contextState',
@@ -18,7 +18,7 @@ const NO_REGISTRY = 'no-registry';
 export const currentDashboardState = selector({
   key: 'dashboardState',
   get:  async ({get}) => {
-    const ocOptions = get(currentOcOptions);
+    const ocOptions = get(currentOcOptionsState);
     const context = get(currentContextState);
     if (context === UnknownKubeContext || !context.clusterUrl) {
       return undefined;
@@ -43,7 +43,7 @@ export const currentDashboardState = selector({
 export const currentOpenShiftRegistryState = selector({
   key: 'openShiftRegistryState',
   get:  async ({get}) => {
-    const ocOptions = get(currentOcOptions);
+    const ocOptions = get(currentOcOptionsState);
     const context = get(currentContextState);
     if (context === UnknownKubeContext || !context.clusterUrl) {
       return undefined;

--- a/client/src/state/currentOcOptionsState.ts
+++ b/client/src/state/currentOcOptionsState.ts
@@ -1,0 +1,9 @@
+import { atom } from "recoil";
+import { OcOptions } from "../models/OcOptions";
+
+export const currentOcOptions = atom<OcOptions>({
+  key: 'ocOptions',
+  default: {
+    skipTlsVerify: false,
+  },
+});

--- a/client/src/state/currentOcOptionsState.ts
+++ b/client/src/state/currentOcOptionsState.ts
@@ -1,7 +1,7 @@
 import { atom } from "recoil";
 import { OcOptions } from "../models/OcOptions";
 
-export const currentOcOptions = atom<OcOptions>({
+export const currentOcOptionsState = atom<OcOptions>({
   key: 'ocOptions',
   default: {
     skipTlsVerify: false,

--- a/client/src/utils/OcUtils.ts
+++ b/client/src/utils/OcUtils.ts
@@ -167,8 +167,8 @@ export function loadContextUiData(kubeConfig: any, contextName: string): KubeCon
 
 }
 
-export async function loadKubeContext(ocOptions: OcOptions): Promise<KubeContext> {
-  const kubeConfig = await readKubeConfig(ocOptions);
+export async function loadKubeContext(): Promise<KubeContext> {
+  const kubeConfig = await readKubeConfig();
   if (kubeConfig) {
     const currentContext = kubeConfig["current-context"];
     if (currentContext) {
@@ -178,9 +178,11 @@ export async function loadKubeContext(ocOptions: OcOptions): Promise<KubeContext
   return UnknownKubeContext;
 }
 
-export async function readKubeConfig(ocOptions: OcOptions): Promise<any> {
+export async function readKubeConfig(): Promise<any> {
   return new Promise((resolve, reject) => {
-    ocExecute(ocOptions, ["config", "view", "-o", "json"])?.then(result => {
+    ocExecute({
+      skipTlsVerify: false,
+    }, ["config", "view", "-o", "json"])?.then(result => {
       if (result.stderr) {
         console.log("stderr:" + result.stderr);
         reject(result.stderr);
@@ -210,8 +212,8 @@ export async function loadProjectNames(ocOptions: OcOptions): Promise<string[]> 
   });
 }
 
-export async function loadServerUrls(ocOptions: OcOptions, kcp: any = undefined): Promise<string[]> {
-  const kc = kcp ? kcp : await readKubeConfig(ocOptions);
+export async function loadServerUrls(kcp: any = undefined): Promise<string[]> {
+  const kc = kcp ? kcp : await readKubeConfig();
   const clusters: string[] = kc.clusters.map((item: any) => item.cluster.server);
   return [... new Set(clusters)];
 }

--- a/client/src/utils/OcUtils.ts
+++ b/client/src/utils/OcUtils.ts
@@ -264,9 +264,13 @@ export async function setCurrentContext(contextName: string): Promise<void> {
   });
 }
 
-export async function login(cluster: string, username: string, password: string): Promise<void> {
+export async function login(cluster: string, username: string, password: string, skipTlsVerify: boolean = false): Promise<void> {
   return new Promise((resolve, reject) => {
-    ddClient.extension?.host?.cli.exec(ocPath, ["login", cluster, '-u', username, '-p', password]).then(result => {
+    const args = ["login", cluster, '-u', username, '-p', password];
+    if (skipTlsVerify) {
+      args.push("--insecure-skip-tls-verify");
+    }
+    ddClient.extension?.host?.cli.exec(ocPath, args).then(result => {
       if (result.stderr) {
         console.log("stderr:" + result.stderr);
         reject(result.stderr);
@@ -279,9 +283,13 @@ export async function login(cluster: string, username: string, password: string)
   });
 }
 
-export async function loginWithToken(cluster: string, token: string): Promise<void> {
+export async function loginWithToken(cluster: string, token: string, skipTlsVerify: boolean = false): Promise<void> {
   return new Promise((resolve, reject) => {
-    ddClient.extension?.host?.cli.exec(ocPath, ["login", cluster, '--token', token]).then(result => {
+    const args = ["login", cluster, '--token', token];
+    if (skipTlsVerify) {
+      args.push("--insecure-skip-tls-verify");
+    }
+    ddClient.extension?.host?.cli.exec(ocPath, args).then(result => {
       if (result.stderr) {
         console.log("stderr:" + result.stderr);
         reject(result.stderr);


### PR DESCRIPTION
Partially implements #50

Adds a `Skip TLS Verify` checkbox to the login dialog that will add [--insecure-skip-tls-verify](https://docs.openshift.com/online/pro/dev_guide/authentication.html) to `oc login` if enabled:
![image](https://user-images.githubusercontent.com/17351764/195652604-467a9fad-efb5-45e5-bfbc-42d8774ca0d9.png)

Because the [--insecure-skip-tls-verify](https://docs.openshift.com/online/pro/dev_guide/authentication.html) option needs to be added to all `oc` commands (thanks to @fbricon for highlighting this), the `boolean` state needs to be stored globally, not just in the login dialog. As such, I've used [recoiljs](https://recoiljs.org/) to do so, to be consistent with the existing implementation (e.g. `KubeContext`).
